### PR TITLE
log -> logrus

### DIFF
--- a/google-beta/batcher.go
+++ b/google-beta/batcher.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sync"
 	"time"
 

--- a/google-beta/batcher_test.go
+++ b/google-beta/batcher_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"sync"
 	"testing"

--- a/google-beta/bootstrap_utils_test.go
+++ b/google-beta/bootstrap_utils_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
 	"testing"

--- a/google-beta/cloud_identity_group_membership_utils.go
+++ b/google-beta/cloud_identity_group_membership_utils.go
@@ -1,7 +1,7 @@
 package google
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/errwrap"

--- a/google-beta/cloudrun_polling.go
+++ b/google-beta/cloudrun_polling.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/errwrap"
 )

--- a/google-beta/common_diff_suppress.go
+++ b/google-beta/common_diff_suppress.go
@@ -5,7 +5,7 @@ package google
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"reflect"
 	"regexp"

--- a/google-beta/common_operation.go
+++ b/google-beta/common_operation.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/google-beta/common_polling.go
+++ b/google-beta/common_polling.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sync"
 	"time"
 

--- a/google-beta/compute_operation.go
+++ b/google-beta/compute_operation.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	compute "google.golang.org/api/compute/v0.beta"

--- a/google-beta/config.go
+++ b/google-beta/config.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"regexp"
 	"strconv"

--- a/google-beta/container_operation.go
+++ b/google-beta/container_operation.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	container "google.golang.org/api/container/v1beta1"

--- a/google-beta/data_source_cloud_run_locations.go
+++ b/google-beta/data_source_cloud_run_locations.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sort"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/data_source_google_composer_image_versions.go
+++ b/google-beta/data_source_google_composer_image_versions.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/google-beta/data_source_google_compute_image.go
+++ b/google-beta/data_source_google_compute_image.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/data_source_google_compute_node_types.go
+++ b/google-beta/data_source_google_compute_node_types.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sort"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/data_source_google_compute_region_instance_group.go
+++ b/google-beta/data_source_google_compute_region_instance_group.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/google-beta/data_source_google_compute_regions.go
+++ b/google-beta/data_source_google_compute_regions.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sort"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/data_source_google_compute_zones.go
+++ b/google-beta/data_source_google_compute_zones.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sort"
 	"strings"
 

--- a/google-beta/data_source_google_kms_crypto_key_version.go
+++ b/google-beta/data_source_google_kms_crypto_key_version.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/data_source_google_kms_secret.go
+++ b/google-beta/data_source_google_kms_secret.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 func dataSourceGoogleKmsSecret() *schema.Resource {

--- a/google-beta/data_source_google_kms_secret_asymmetric_test.go
+++ b/google-beta/data_source_google_kms_secret_asymmetric_test.go
@@ -9,7 +9,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"hash/crc32"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/google-beta/data_source_google_kms_secret_ciphertext.go
+++ b/google-beta/data_source_google_kms_secret_ciphertext.go
@@ -5,7 +5,7 @@ import (
 
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/google-beta/data_source_google_kms_secret_test.go
+++ b/google-beta/data_source_google_kms_secret_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/google-beta/data_source_google_service_account_access_token.go
+++ b/google-beta/data_source_google_service_account_access_token.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"strings"
 

--- a/google-beta/data_source_google_sql_ca_certs.go
+++ b/google-beta/data_source_google_sql_ca_certs.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/google-beta/data_source_google_storage_bucket.go
+++ b/google-beta/data_source_google_storage_bucket.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 func dataSourceGoogleStorageBucket() *schema.Resource {

--- a/google-beta/data_source_secret_manager_secret_version.go
+++ b/google-beta/data_source_secret_manager_secret_version.go
@@ -3,7 +3,7 @@ package google
 import (
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/data_source_secret_manager_secret_version_access.go
+++ b/google-beta/data_source_secret_manager_secret_version_access.go
@@ -3,7 +3,7 @@ package google
 import (
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/data_source_storage_object_signed_url.go
+++ b/google-beta/data_source_storage_object_signed_url.go
@@ -11,7 +11,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/url"
 	"os"
 	"sort"

--- a/google-beta/data_source_tpu_tensorflow_versions.go
+++ b/google-beta/data_source_tpu_tensorflow_versions.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sort"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/dcl_logger.go
+++ b/google-beta/dcl_logger.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 type dclLogger struct{}

--- a/google-beta/error_retry_predicates.go
+++ b/google-beta/error_retry_predicates.go
@@ -3,7 +3,7 @@ package google
 import (
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"net/url"
 	"regexp"

--- a/google-beta/framework_provider_test.go
+++ b/google-beta/framework_provider_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"os"
 	"path/filepath"

--- a/google-beta/iam.go
+++ b/google-beta/iam.go
@@ -4,7 +4,7 @@ package google
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"sort"
 	"strings"

--- a/google-beta/import.go
+++ b/google-beta/import.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strconv"
 	"strings"

--- a/google-beta/metadata.go
+++ b/google-beta/metadata.go
@@ -3,7 +3,7 @@ package google
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sort"
 
 	compute "google.golang.org/api/compute/v0.beta"

--- a/google-beta/mutexkv.go
+++ b/google-beta/mutexkv.go
@@ -1,7 +1,7 @@
 package google
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sync"
 )
 

--- a/google-beta/privateca_ca_utils.go
+++ b/google-beta/privateca_ca_utils.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"math/rand"
 	"regexp"
 	"time"

--- a/google-beta/provider_test.go
+++ b/google-beta/provider_test.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"math/rand"
 	"net/http"
 	"os"

--- a/google-beta/resource_access_approval_folder_settings_test.go
+++ b/google-beta/resource_access_approval_folder_settings_test.go
@@ -1,7 +1,7 @@
 package google
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_access_approval_organization_settings_test.go
+++ b/google-beta/resource_access_approval_organization_settings_test.go
@@ -1,7 +1,7 @@
 package google
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_access_approval_project_settings_test.go
+++ b/google-beta/resource_access_approval_project_settings_test.go
@@ -1,7 +1,7 @@
 package google
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_access_context_manager_access_level.go
+++ b/google-beta/resource_access_context_manager_access_level.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_access_context_manager_access_level_condition.go
+++ b/google-beta/resource_access_context_manager_access_level_condition.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_access_context_manager_access_levels.go
+++ b/google-beta/resource_access_context_manager_access_levels.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_access_context_manager_access_policy.go
+++ b/google-beta/resource_access_context_manager_access_policy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_access_context_manager_access_policy_test.go
+++ b/google-beta/resource_access_context_manager_access_policy_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	neturl "net/url"
 	"testing"
 

--- a/google-beta/resource_access_context_manager_gcp_user_access_binding.go
+++ b/google-beta/resource_access_context_manager_gcp_user_access_binding.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_access_context_manager_gcp_user_access_binding_sweeper_test.go
+++ b/google-beta/resource_access_context_manager_gcp_user_access_binding_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_access_context_manager_service_perimeter.go
+++ b/google-beta/resource_access_context_manager_service_perimeter.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_access_context_manager_service_perimeter_resource.go
+++ b/google-beta/resource_access_context_manager_service_perimeter_resource.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_access_context_manager_service_perimeters.go
+++ b/google-beta/resource_access_context_manager_service_perimeters.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_active_directory_domain.go
+++ b/google-beta/resource_active_directory_domain.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_active_directory_domain_sweeper_test.go
+++ b/google-beta/resource_active_directory_domain_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_active_directory_domain_trust.go
+++ b/google-beta/resource_active_directory_domain_trust.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_active_directory_peering.go
+++ b/google-beta/resource_active_directory_peering.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_active_directory_peering_sweeper_test.go
+++ b/google-beta/resource_active_directory_peering_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_alloydb_backup.go
+++ b/google-beta/resource_alloydb_backup.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_alloydb_backup_sweeper_test.go
+++ b/google-beta/resource_alloydb_backup_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_alloydb_cluster.go
+++ b/google-beta/resource_alloydb_cluster.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_alloydb_cluster_sweeper_test.go
+++ b/google-beta/resource_alloydb_cluster_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_alloydb_instance.go
+++ b/google-beta/resource_alloydb_instance.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_alloydb_instance_sweeper_test.go
+++ b/google-beta/resource_alloydb_instance_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_api_gateway_api.go
+++ b/google-beta/resource_api_gateway_api.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_api_gateway_api_config.go
+++ b/google-beta/resource_api_gateway_api_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_api_gateway_api_config_sweeper_test.go
+++ b/google-beta/resource_api_gateway_api_config_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_api_gateway_api_sweeper_test.go
+++ b/google-beta/resource_api_gateway_api_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_api_gateway_gateway.go
+++ b/google-beta/resource_api_gateway_gateway.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_api_gateway_gateway_sweeper_test.go
+++ b/google-beta/resource_api_gateway_gateway_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_apigee_addons_config.go
+++ b/google-beta/resource_apigee_addons_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_apigee_addons_config_sweeper_test.go
+++ b/google-beta/resource_apigee_addons_config_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_apigee_endpoint_attachment.go
+++ b/google-beta/resource_apigee_endpoint_attachment.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_apigee_envgroup.go
+++ b/google-beta/resource_apigee_envgroup.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_apigee_envgroup_attachment.go
+++ b/google-beta/resource_apigee_envgroup_attachment.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_apigee_envgroup_sweeper_test.go
+++ b/google-beta/resource_apigee_envgroup_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_apigee_environment.go
+++ b/google-beta/resource_apigee_environment.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_apigee_environment_sweeper_test.go
+++ b/google-beta/resource_apigee_environment_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_apigee_instance.go
+++ b/google-beta/resource_apigee_instance.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_apigee_instance_attachment.go
+++ b/google-beta/resource_apigee_instance_attachment.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_apigee_instance_attachment_sweeper_test.go
+++ b/google-beta/resource_apigee_instance_attachment_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_apigee_instance_sweeper_test.go
+++ b/google-beta/resource_apigee_instance_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_apigee_nat_address.go
+++ b/google-beta/resource_apigee_nat_address.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_apigee_organization.go
+++ b/google-beta/resource_apigee_organization.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_apigee_organization_sweeper_test.go
+++ b/google-beta/resource_apigee_organization_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_apigee_sync_authorization.go
+++ b/google-beta/resource_apigee_sync_authorization.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_apikeys_key.go
+++ b/google-beta/resource_apikeys_key.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_apikeys_key_sweeper_test.go
+++ b/google-beta/resource_apikeys_key_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	apikeys "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/apikeys/beta"

--- a/google-beta/resource_app_engine_app_version_sweeper_test.go
+++ b/google-beta/resource_app_engine_app_version_sweeper_test.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/google-beta/resource_app_engine_application.go
+++ b/google-beta/resource_app_engine_application.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"

--- a/google-beta/resource_app_engine_application_url_dispatch_rules.go
+++ b/google-beta/resource_app_engine_application_url_dispatch_rules.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_app_engine_application_url_dispatch_rules_generated_test.go
+++ b/google-beta/resource_app_engine_application_url_dispatch_rules_generated_test.go
@@ -15,7 +15,7 @@
 package google
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_app_engine_domain_mapping.go
+++ b/google-beta/resource_app_engine_domain_mapping.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_app_engine_domain_mapping_sweeper_test.go
+++ b/google-beta/resource_app_engine_domain_mapping_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_app_engine_firewall_rule.go
+++ b/google-beta/resource_app_engine_firewall_rule.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_app_engine_flexible_app_version.go
+++ b/google-beta/resource_app_engine_flexible_app_version.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_app_engine_flexible_app_version_generated_test.go
+++ b/google-beta/resource_app_engine_flexible_app_version_generated_test.go
@@ -15,7 +15,7 @@
 package google
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_app_engine_service_network_settings.go
+++ b/google-beta/resource_app_engine_service_network_settings.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_app_engine_service_split_traffic.go
+++ b/google-beta/resource_app_engine_service_split_traffic.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_app_engine_standard_app_version.go
+++ b/google-beta/resource_app_engine_standard_app_version.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_app_engine_standard_app_version_generated_test.go
+++ b/google-beta/resource_app_engine_standard_app_version_generated_test.go
@@ -15,7 +15,7 @@
 package google
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_artifact_registry_repository.go
+++ b/google-beta/resource_artifact_registry_repository.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_artifact_registry_repository_sweeper_test.go
+++ b/google-beta/resource_artifact_registry_repository_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_assured_workloads_workload.go
+++ b/google-beta/resource_assured_workloads_workload.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_beyondcorp_app_connection.go
+++ b/google-beta/resource_beyondcorp_app_connection.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_beyondcorp_app_connection_sweeper_test.go
+++ b/google-beta/resource_beyondcorp_app_connection_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_beyondcorp_app_connector.go
+++ b/google-beta/resource_beyondcorp_app_connector.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_beyondcorp_app_connector_sweeper_test.go
+++ b/google-beta/resource_beyondcorp_app_connector_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_beyondcorp_app_gateway.go
+++ b/google-beta/resource_beyondcorp_app_gateway.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_beyondcorp_app_gateway_sweeper_test.go
+++ b/google-beta/resource_beyondcorp_app_gateway_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_bigquery_analytics_hub_data_exchange.go
+++ b/google-beta/resource_bigquery_analytics_hub_data_exchange.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_bigquery_analytics_hub_data_exchange_sweeper_test.go
+++ b/google-beta/resource_bigquery_analytics_hub_data_exchange_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_bigquery_analytics_hub_listing.go
+++ b/google-beta/resource_bigquery_analytics_hub_listing.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_bigquery_analytics_hub_listing_sweeper_test.go
+++ b/google-beta/resource_bigquery_analytics_hub_listing_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_bigquery_connection.go
+++ b/google-beta/resource_bigquery_connection.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_bigquery_connection_sweeper_test.go
+++ b/google-beta/resource_bigquery_connection_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_bigquery_data_transfer_config.go
+++ b/google-beta/resource_bigquery_data_transfer_config.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_bigquery_data_transfer_config_sweeper_test.go
+++ b/google-beta/resource_bigquery_data_transfer_config_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_bigquery_datapolicy_data_policy.go
+++ b/google-beta/resource_bigquery_datapolicy_data_policy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_bigquery_datapolicy_data_policy_sweeper_test.go
+++ b/google-beta/resource_bigquery_datapolicy_data_policy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_bigquery_dataset.go
+++ b/google-beta/resource_bigquery_dataset.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"time"

--- a/google-beta/resource_bigquery_dataset_access.go
+++ b/google-beta/resource_bigquery_dataset_access.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_bigquery_job.go
+++ b/google-beta/resource_bigquery_job.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"time"

--- a/google-beta/resource_bigquery_reservation.go
+++ b/google-beta/resource_bigquery_reservation.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_bigquery_reservation_assignment.go
+++ b/google-beta/resource_bigquery_reservation_assignment.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_bigquery_reservation_sweeper_test.go
+++ b/google-beta/resource_bigquery_reservation_sweeper_test.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/google-beta/resource_bigquery_routine.go
+++ b/google-beta/resource_bigquery_routine.go
@@ -17,7 +17,7 @@ package google
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_bigquery_routine_sweeper_test.go
+++ b/google-beta/resource_bigquery_routine_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_bigquery_table.go
+++ b/google-beta/resource_bigquery_table.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"sort"

--- a/google-beta/resource_bigtable_app_profile.go
+++ b/google-beta/resource_bigtable_app_profile.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_bigtable_gc_policy.go
+++ b/google-beta/resource_bigtable_gc_policy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google-beta/resource_bigtable_instance.go
+++ b/google-beta/resource_bigtable_instance.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_bigtable_instance_migrate.go
+++ b/google-beta/resource_bigtable_instance_migrate.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/google-beta/resource_bigtable_instance_sweeper_test.go
+++ b/google-beta/resource_bigtable_instance_sweeper_test.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/google-beta/resource_bigtable_table.go
+++ b/google-beta/resource_bigtable_table.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"cloud.google.com/go/bigtable"

--- a/google-beta/resource_billing_budget.go
+++ b/google-beta/resource_billing_budget.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_billing_budget_sweeper_test.go
+++ b/google-beta/resource_billing_budget_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_binary_authorization_attestor.go
+++ b/google-beta/resource_binary_authorization_attestor.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"time"

--- a/google-beta/resource_binary_authorization_attestor_sweeper_test.go
+++ b/google-beta/resource_binary_authorization_attestor_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_binary_authorization_policy.go
+++ b/google-beta/resource_binary_authorization_policy.go
@@ -17,7 +17,7 @@ package google
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"time"

--- a/google-beta/resource_certificate_manager_certificate.go
+++ b/google-beta/resource_certificate_manager_certificate.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_certificate_manager_certificate_map.go
+++ b/google-beta/resource_certificate_manager_certificate_map.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_certificate_manager_certificate_map_entry.go
+++ b/google-beta/resource_certificate_manager_certificate_map_entry.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_certificate_manager_certificate_map_entry_sweeper_test.go
+++ b/google-beta/resource_certificate_manager_certificate_map_entry_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_certificate_manager_certificate_map_sweeper_test.go
+++ b/google-beta/resource_certificate_manager_certificate_map_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_certificate_manager_certificate_sweeper_test.go
+++ b/google-beta/resource_certificate_manager_certificate_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_certificate_manager_dns_authorization.go
+++ b/google-beta/resource_certificate_manager_dns_authorization.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_certificate_manager_dns_authorization_sweeper_test.go
+++ b/google-beta/resource_certificate_manager_dns_authorization_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_cloud_asset_folder_feed.go
+++ b/google-beta/resource_cloud_asset_folder_feed.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_cloud_asset_folder_feed_sweeper_test.go
+++ b/google-beta/resource_cloud_asset_folder_feed_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_cloud_asset_organization_feed.go
+++ b/google-beta/resource_cloud_asset_organization_feed.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_cloud_asset_organization_feed_sweeper_test.go
+++ b/google-beta/resource_cloud_asset_organization_feed_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_cloud_asset_project_feed.go
+++ b/google-beta/resource_cloud_asset_project_feed.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_cloud_asset_project_feed_sweeper_test.go
+++ b/google-beta/resource_cloud_asset_project_feed_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_cloud_identity_group.go
+++ b/google-beta/resource_cloud_identity_group.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_cloud_identity_group_membership.go
+++ b/google-beta/resource_cloud_identity_group_membership.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"time"

--- a/google-beta/resource_cloud_identity_group_sweeper_test.go
+++ b/google-beta/resource_cloud_identity_group_sweeper_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/url"
 	"testing"
 

--- a/google-beta/resource_cloud_ids_endpoint.go
+++ b/google-beta/resource_cloud_ids_endpoint.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_cloud_run_domain_mapping.go
+++ b/google-beta/resource_cloud_run_domain_mapping.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_cloud_run_domain_mapping_sweeper_test.go
+++ b/google-beta/resource_cloud_run_domain_mapping_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_cloud_run_service.go
+++ b/google-beta/resource_cloud_run_service.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_cloud_run_service_sweeper_test.go
+++ b/google-beta/resource_cloud_run_service_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_cloud_run_v2_job.go
+++ b/google-beta/resource_cloud_run_v2_job.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_cloud_run_v2_job_sweeper_test.go
+++ b/google-beta/resource_cloud_run_v2_job_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_cloud_run_v2_service.go
+++ b/google-beta/resource_cloud_run_v2_service.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_cloud_run_v2_service_sweeper_test.go
+++ b/google-beta/resource_cloud_run_v2_service_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_cloud_scheduler_job.go
+++ b/google-beta/resource_cloud_scheduler_job.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_cloud_scheduler_job_sweeper_test.go
+++ b/google-beta/resource_cloud_scheduler_job_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_cloud_tasks_queue.go
+++ b/google-beta/resource_cloud_tasks_queue.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_cloud_tasks_queue_sweeper_test.go
+++ b/google-beta/resource_cloud_tasks_queue_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_cloudbuild_trigger.go
+++ b/google-beta/resource_cloudbuild_trigger.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_cloudbuild_trigger_sweeper_test.go
+++ b/google-beta/resource_cloudbuild_trigger_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_cloudbuild_worker_pool.go
+++ b/google-beta/resource_cloudbuild_worker_pool.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_cloudbuild_worker_pool_sweeper_test.go
+++ b/google-beta/resource_cloudbuild_worker_pool_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	cloudbuild "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/cloudbuild/beta"

--- a/google-beta/resource_cloudbuildv2_connection.go
+++ b/google-beta/resource_cloudbuildv2_connection.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_cloudbuildv2_connection_sweeper_test.go
+++ b/google-beta/resource_cloudbuildv2_connection_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	cloudbuildv2 "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/cloudbuildv2/beta"

--- a/google-beta/resource_cloudbuildv2_repository.go
+++ b/google-beta/resource_cloudbuildv2_repository.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_clouddeploy_delivery_pipeline.go
+++ b/google-beta/resource_clouddeploy_delivery_pipeline.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_clouddeploy_delivery_pipeline_sweeper_test.go
+++ b/google-beta/resource_clouddeploy_delivery_pipeline_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	clouddeploy "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/clouddeploy/beta"

--- a/google-beta/resource_clouddeploy_target.go
+++ b/google-beta/resource_clouddeploy_target.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_clouddeploy_target_sweeper_test.go
+++ b/google-beta/resource_clouddeploy_target_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	clouddeploy "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/clouddeploy/beta"

--- a/google-beta/resource_cloudfunctions2_function.go
+++ b/google-beta/resource_cloudfunctions2_function.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_cloudfunctions2_function_sweeper_test.go
+++ b/google-beta/resource_cloudfunctions2_function_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_cloudfunctions_function.go
+++ b/google-beta/resource_cloudfunctions_function.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/api/cloudfunctions/v1"
 
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/url"
 	"strconv"
 	"strings"

--- a/google-beta/resource_cloudfunctions_function_test.go
+++ b/google-beta/resource_cloudfunctions_function_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
 	"testing"

--- a/google-beta/resource_cloudiot_device.go
+++ b/google-beta/resource_cloudiot_device.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_cloudiot_device_sweeper_test.go
+++ b/google-beta/resource_cloudiot_device_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_cloudiot_registry.go
+++ b/google-beta/resource_cloudiot_registry.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_cloudiot_registry_sweeper_test.go
+++ b/google-beta/resource_cloudiot_registry_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_composer_environment.go
+++ b/google-beta/resource_composer_environment.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strings"
 	"time"

--- a/google-beta/resource_composer_environment_test.go
+++ b/google-beta/resource_composer_environment_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strings"
 	"time"

--- a/google-beta/resource_compute_address.go
+++ b/google-beta/resource_compute_address.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_address_sweeper_test.go
+++ b/google-beta/resource_compute_address_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_attached_disk.go
+++ b/google-beta/resource_compute_attached_disk.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google-beta/resource_compute_autoscaler.go
+++ b/google-beta/resource_compute_autoscaler.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_autoscaler_sweeper_test.go
+++ b/google-beta/resource_compute_autoscaler_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_backend_bucket.go
+++ b/google-beta/resource_compute_backend_bucket.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_backend_bucket_signed_url_key.go
+++ b/google-beta/resource_compute_backend_bucket_signed_url_key.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_backend_bucket_signed_url_key_sweeper_test.go
+++ b/google-beta/resource_compute_backend_bucket_signed_url_key_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_backend_bucket_sweeper_test.go
+++ b/google-beta/resource_compute_backend_bucket_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_backend_service.go
+++ b/google-beta/resource_compute_backend_service.go
@@ -17,7 +17,7 @@ package google
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"time"

--- a/google-beta/resource_compute_backend_service_signed_url_key.go
+++ b/google-beta/resource_compute_backend_service_signed_url_key.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_backend_service_signed_url_key_sweeper_test.go
+++ b/google-beta/resource_compute_backend_service_signed_url_key_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_backend_service_sweeper_test.go
+++ b/google-beta/resource_compute_backend_service_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_disk.go
+++ b/google-beta/resource_compute_disk.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_compute_disk_resource_policy_attachment.go
+++ b/google-beta/resource_compute_disk_resource_policy_attachment.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_disk_sweeper_test.go
+++ b/google-beta/resource_compute_disk_sweeper_test.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/google-beta/resource_compute_external_vpn_gateway.go
+++ b/google-beta/resource_compute_external_vpn_gateway.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_external_vpn_gateway_sweeper_test.go
+++ b/google-beta/resource_compute_external_vpn_gateway_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_firewall.go
+++ b/google-beta/resource_compute_firewall.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"sort"
 	"strings"

--- a/google-beta/resource_compute_firewall_migrate.go
+++ b/google-beta/resource_compute_firewall_migrate.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sort"
 	"strconv"
 	"strings"

--- a/google-beta/resource_compute_firewall_policy.go
+++ b/google-beta/resource_compute_firewall_policy.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_compute_firewall_policy_association.go
+++ b/google-beta/resource_compute_firewall_policy_association.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_compute_firewall_policy_rule.go
+++ b/google-beta/resource_compute_firewall_policy_rule.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_compute_firewall_sweeper_test.go
+++ b/google-beta/resource_compute_firewall_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_forwarding_rule.go
+++ b/google-beta/resource_compute_forwarding_rule.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_compute_forwarding_rule_sweeper_test.go
+++ b/google-beta/resource_compute_forwarding_rule_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	compute "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/compute/beta"

--- a/google-beta/resource_compute_global_address.go
+++ b/google-beta/resource_compute_global_address.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_global_address_sweeper_test.go
+++ b/google-beta/resource_compute_global_address_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_global_forwarding_rule.go
+++ b/google-beta/resource_compute_global_forwarding_rule.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_compute_global_forwarding_rule_sweeper_test.go
+++ b/google-beta/resource_compute_global_forwarding_rule_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	compute "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/compute/beta"

--- a/google-beta/resource_compute_global_network_endpoint.go
+++ b/google-beta/resource_compute_global_network_endpoint.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_global_network_endpoint_group.go
+++ b/google-beta/resource_compute_global_network_endpoint_group.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_global_network_endpoint_group_sweeper_test.go
+++ b/google-beta/resource_compute_global_network_endpoint_group_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_ha_vpn_gateway.go
+++ b/google-beta/resource_compute_ha_vpn_gateway.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_ha_vpn_gateway_sweeper_test.go
+++ b/google-beta/resource_compute_ha_vpn_gateway_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_health_check.go
+++ b/google-beta/resource_compute_health_check.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strconv"
 	"strings"

--- a/google-beta/resource_compute_health_check_sweeper_test.go
+++ b/google-beta/resource_compute_health_check_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_http_health_check.go
+++ b/google-beta/resource_compute_http_health_check.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_http_health_check_sweeper_test.go
+++ b/google-beta/resource_compute_http_health_check_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_https_health_check.go
+++ b/google-beta/resource_compute_https_health_check.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_https_health_check_sweeper_test.go
+++ b/google-beta/resource_compute_https_health_check_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_image.go
+++ b/google-beta/resource_compute_image.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_compute_image_sweeper_test.go
+++ b/google-beta/resource_compute_image_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_instance.go
+++ b/google-beta/resource_compute_instance.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 	"time"

--- a/google-beta/resource_compute_instance_from_machine_image.go
+++ b/google-beta/resource_compute_instance_from_machine_image.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_compute_instance_from_template.go
+++ b/google-beta/resource_compute_instance_from_template.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/google-beta/resource_compute_instance_group.go
+++ b/google-beta/resource_compute_instance_group.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google-beta/resource_compute_instance_group_manager.go
+++ b/google-beta/resource_compute_instance_group_manager.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google-beta/resource_compute_instance_group_manager_test.go
+++ b/google-beta/resource_compute_instance_group_manager_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/google-beta/resource_compute_instance_group_migrate.go
+++ b/google-beta/resource_compute_instance_group_migrate.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 

--- a/google-beta/resource_compute_instance_group_named_port.go
+++ b/google-beta/resource_compute_instance_group_named_port.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_instance_group_named_port_sweeper_test.go
+++ b/google-beta/resource_compute_instance_group_named_port_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_instance_migrate.go
+++ b/google-beta/resource_compute_instance_migrate.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 

--- a/google-beta/resource_compute_instance_migrate_test.go
+++ b/google-beta/resource_compute_instance_migrate_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
 	"testing"

--- a/google-beta/resource_compute_instance_template_migrate.go
+++ b/google-beta/resource_compute_instance_template_migrate.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )

--- a/google-beta/resource_compute_instance_template_sweeper_test.go
+++ b/google-beta/resource_compute_instance_template_sweeper_test.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/google-beta/resource_compute_instance_test.go
+++ b/google-beta/resource_compute_instance_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"sort"

--- a/google-beta/resource_compute_interconnect_attachment.go
+++ b/google-beta/resource_compute_interconnect_attachment.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_machine_image.go
+++ b/google-beta/resource_compute_machine_image.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_machine_image_sweeper_test.go
+++ b/google-beta/resource_compute_machine_image_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_managed_ssl_certificate.go
+++ b/google-beta/resource_compute_managed_ssl_certificate.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_managed_ssl_certificate_sweeper_test.go
+++ b/google-beta/resource_compute_managed_ssl_certificate_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_network.go
+++ b/google-beta/resource_compute_network.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_network_endpoint.go
+++ b/google-beta/resource_compute_network_endpoint.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_network_endpoint_group.go
+++ b/google-beta/resource_compute_network_endpoint_group.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_network_endpoint_group_sweeper_test.go
+++ b/google-beta/resource_compute_network_endpoint_group_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_network_firewall_policy.go
+++ b/google-beta/resource_compute_network_firewall_policy.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_compute_network_firewall_policy_association.go
+++ b/google-beta/resource_compute_network_firewall_policy_association.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_compute_network_firewall_policy_rule.go
+++ b/google-beta/resource_compute_network_firewall_policy_rule.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_compute_network_firewall_policy_sweeper_test.go
+++ b/google-beta/resource_compute_network_firewall_policy_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	compute "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/compute/beta"

--- a/google-beta/resource_compute_network_peering.go
+++ b/google-beta/resource_compute_network_peering.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sort"
 	"strings"
 	"time"

--- a/google-beta/resource_compute_network_peering_routes_config.go
+++ b/google-beta/resource_compute_network_peering_routes_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_network_sweeper_test.go
+++ b/google-beta/resource_compute_network_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_node_group.go
+++ b/google-beta/resource_compute_node_group.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"time"

--- a/google-beta/resource_compute_node_group_sweeper_test.go
+++ b/google-beta/resource_compute_node_group_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_node_template.go
+++ b/google-beta/resource_compute_node_template.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_node_template_sweeper_test.go
+++ b/google-beta/resource_compute_node_template_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_organization_security_policy.go
+++ b/google-beta/resource_compute_organization_security_policy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_organization_security_policy_association.go
+++ b/google-beta/resource_compute_organization_security_policy_association.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_organization_security_policy_association_generated_test.go
+++ b/google-beta/resource_compute_organization_security_policy_association_generated_test.go
@@ -15,7 +15,7 @@
 package google
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_organization_security_policy_generated_test.go
+++ b/google-beta/resource_compute_organization_security_policy_generated_test.go
@@ -15,7 +15,7 @@
 package google
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_organization_security_policy_rule.go
+++ b/google-beta/resource_compute_organization_security_policy_rule.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_organization_security_policy_rule_generated_test.go
+++ b/google-beta/resource_compute_organization_security_policy_rule_generated_test.go
@@ -15,7 +15,7 @@
 package google
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_packet_mirroring.go
+++ b/google-beta/resource_compute_packet_mirroring.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_packet_mirroring_sweeper_test.go
+++ b/google-beta/resource_compute_packet_mirroring_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_per_instance_config.go
+++ b/google-beta/resource_compute_per_instance_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_project_default_network_tier.go
+++ b/google-beta/resource_compute_project_default_network_tier.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/google-beta/resource_compute_project_metadata.go
+++ b/google-beta/resource_compute_project_metadata.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_compute_project_metadata_item.go
+++ b/google-beta/resource_compute_project_metadata_item.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_compute_region_autoscaler.go
+++ b/google-beta/resource_compute_region_autoscaler.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_region_autoscaler_sweeper_test.go
+++ b/google-beta/resource_compute_region_autoscaler_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_region_backend_service.go
+++ b/google-beta/resource_compute_region_backend_service.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_region_backend_service_sweeper_test.go
+++ b/google-beta/resource_compute_region_backend_service_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_region_disk.go
+++ b/google-beta/resource_compute_region_disk.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_compute_region_disk_resource_policy_attachment.go
+++ b/google-beta/resource_compute_region_disk_resource_policy_attachment.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_region_health_check.go
+++ b/google-beta/resource_compute_region_health_check.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_region_health_check_sweeper_test.go
+++ b/google-beta/resource_compute_region_health_check_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_region_instance_group_manager.go
+++ b/google-beta/resource_compute_region_instance_group_manager.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google-beta/resource_compute_region_instance_group_manager_test.go
+++ b/google-beta/resource_compute_region_instance_group_manager_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_region_network_endpoint_group.go
+++ b/google-beta/resource_compute_region_network_endpoint_group.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_region_network_endpoint_group_sweeper_test.go
+++ b/google-beta/resource_compute_region_network_endpoint_group_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_region_network_firewall_policy.go
+++ b/google-beta/resource_compute_region_network_firewall_policy.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_compute_region_network_firewall_policy_association.go
+++ b/google-beta/resource_compute_region_network_firewall_policy_association.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_compute_region_network_firewall_policy_rule.go
+++ b/google-beta/resource_compute_region_network_firewall_policy_rule.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_compute_region_network_firewall_policy_sweeper_test.go
+++ b/google-beta/resource_compute_region_network_firewall_policy_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	compute "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/compute/beta"

--- a/google-beta/resource_compute_region_per_instance_config.go
+++ b/google-beta/resource_compute_region_per_instance_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_region_ssl_certificate.go
+++ b/google-beta/resource_compute_region_ssl_certificate.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_region_ssl_certificate_sweeper_test.go
+++ b/google-beta/resource_compute_region_ssl_certificate_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_region_ssl_policy.go
+++ b/google-beta/resource_compute_region_ssl_policy.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_region_ssl_policy_sweeper_test.go
+++ b/google-beta/resource_compute_region_ssl_policy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_region_target_http_proxy.go
+++ b/google-beta/resource_compute_region_target_http_proxy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_region_target_http_proxy_sweeper_test.go
+++ b/google-beta/resource_compute_region_target_http_proxy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_region_target_https_proxy.go
+++ b/google-beta/resource_compute_region_target_https_proxy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_region_target_https_proxy_sweeper_test.go
+++ b/google-beta/resource_compute_region_target_https_proxy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_region_target_tcp_proxy.go
+++ b/google-beta/resource_compute_region_target_tcp_proxy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_region_target_tcp_proxy_sweeper_test.go
+++ b/google-beta/resource_compute_region_target_tcp_proxy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_region_url_map.go
+++ b/google-beta/resource_compute_region_url_map.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_region_url_map_sweeper_test.go
+++ b/google-beta/resource_compute_region_url_map_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_reservation.go
+++ b/google-beta/resource_compute_reservation.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/url"
 	"reflect"
 	"strconv"

--- a/google-beta/resource_compute_reservation_sweeper_test.go
+++ b/google-beta/resource_compute_reservation_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_resource_policy.go
+++ b/google-beta/resource_compute_resource_policy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_resource_policy_sweeper_test.go
+++ b/google-beta/resource_compute_resource_policy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_route.go
+++ b/google-beta/resource_compute_route.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_route_sweeper_test.go
+++ b/google-beta/resource_compute_route_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_router.go
+++ b/google-beta/resource_compute_router.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_router_interface.go
+++ b/google-beta/resource_compute_router_interface.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"strings"

--- a/google-beta/resource_compute_router_nat.go
+++ b/google-beta/resource_compute_router_nat.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_compute_router_nat_sweeper_test.go
+++ b/google-beta/resource_compute_router_nat_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_router_peer.go
+++ b/google-beta/resource_compute_router_peer.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strconv"
 	"strings"

--- a/google-beta/resource_compute_router_peer_sweeper_test.go
+++ b/google-beta/resource_compute_router_peer_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_router_sweeper_test.go
+++ b/google-beta/resource_compute_router_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_security_policy.go
+++ b/google-beta/resource_compute_security_policy.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"time"
 

--- a/google-beta/resource_compute_service_attachment.go
+++ b/google-beta/resource_compute_service_attachment.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_service_attachment_sweeper_test.go
+++ b/google-beta/resource_compute_service_attachment_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_shared_vpc_host_project.go
+++ b/google-beta/resource_compute_shared_vpc_host_project.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_compute_shared_vpc_service_project.go
+++ b/google-beta/resource_compute_shared_vpc_service_project.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google-beta/resource_compute_snapshot.go
+++ b/google-beta/resource_compute_snapshot.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_compute_snapshot_sweeper_test.go
+++ b/google-beta/resource_compute_snapshot_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_ssl_certificate.go
+++ b/google-beta/resource_compute_ssl_certificate.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_ssl_certificate_sweeper_test.go
+++ b/google-beta/resource_compute_ssl_certificate_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_ssl_policy.go
+++ b/google-beta/resource_compute_ssl_policy.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_ssl_policy_sweeper_test.go
+++ b/google-beta/resource_compute_ssl_policy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_subnetwork.go
+++ b/google-beta/resource_compute_subnetwork.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"reflect"
 	"time"

--- a/google-beta/resource_compute_subnetwork_sweeper_test.go
+++ b/google-beta/resource_compute_subnetwork_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_target_grpc_proxy.go
+++ b/google-beta/resource_compute_target_grpc_proxy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_target_grpc_proxy_sweeper_test.go
+++ b/google-beta/resource_compute_target_grpc_proxy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_target_http_proxy.go
+++ b/google-beta/resource_compute_target_http_proxy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_target_http_proxy_sweeper_test.go
+++ b/google-beta/resource_compute_target_http_proxy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_target_https_proxy.go
+++ b/google-beta/resource_compute_target_https_proxy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_target_https_proxy_sweeper_test.go
+++ b/google-beta/resource_compute_target_https_proxy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_target_instance.go
+++ b/google-beta/resource_compute_target_instance.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_compute_target_instance_sweeper_test.go
+++ b/google-beta/resource_compute_target_instance_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_target_pool.go
+++ b/google-beta/resource_compute_target_pool.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strings"
 	"time"

--- a/google-beta/resource_compute_target_ssl_proxy.go
+++ b/google-beta/resource_compute_target_ssl_proxy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_target_ssl_proxy_sweeper_test.go
+++ b/google-beta/resource_compute_target_ssl_proxy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_target_tcp_proxy.go
+++ b/google-beta/resource_compute_target_tcp_proxy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_target_tcp_proxy_sweeper_test.go
+++ b/google-beta/resource_compute_target_tcp_proxy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_url_map.go
+++ b/google-beta/resource_compute_url_map.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_compute_url_map_sweeper_test.go
+++ b/google-beta/resource_compute_url_map_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_vpn_gateway.go
+++ b/google-beta/resource_compute_vpn_gateway.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_compute_vpn_gateway_sweeper_test.go
+++ b/google-beta/resource_compute_vpn_gateway_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_compute_vpn_tunnel.go
+++ b/google-beta/resource_compute_vpn_tunnel.go
@@ -17,7 +17,7 @@ package google
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"reflect"
 	"strings"

--- a/google-beta/resource_compute_vpn_tunnel_sweeper_test.go
+++ b/google-beta/resource_compute_vpn_tunnel_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_container_analysis_note.go
+++ b/google-beta/resource_container_analysis_note.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_container_analysis_note_sweeper_test.go
+++ b/google-beta/resource_container_analysis_note_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_container_analysis_occurrence.go
+++ b/google-beta/resource_container_analysis_occurrence.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_container_analysis_occurrence_sweeper_test.go
+++ b/google-beta/resource_container_analysis_occurrence_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_container_attached_cluster.go
+++ b/google-beta/resource_container_attached_cluster.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_container_aws_cluster.go
+++ b/google-beta/resource_container_aws_cluster.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_container_aws_cluster_sweeper_test.go
+++ b/google-beta/resource_container_aws_cluster_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	containeraws "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/containeraws/beta"

--- a/google-beta/resource_container_aws_node_pool.go
+++ b/google-beta/resource_container_aws_node_pool.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_container_azure_client.go
+++ b/google-beta/resource_container_azure_client.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_container_azure_client_sweeper_test.go
+++ b/google-beta/resource_container_azure_client_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	containerazure "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/containerazure/beta"

--- a/google-beta/resource_container_azure_cluster.go
+++ b/google-beta/resource_container_azure_cluster.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_container_azure_cluster_sweeper_test.go
+++ b/google-beta/resource_container_azure_cluster_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	containerazure "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/containerazure/beta"

--- a/google-beta/resource_container_azure_node_pool.go
+++ b/google-beta/resource_container_azure_node_pool.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_container_cluster.go
+++ b/google-beta/resource_container_cluster.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_container_cluster_migrate.go
+++ b/google-beta/resource_container_cluster_migrate.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 

--- a/google-beta/resource_container_cluster_test.go
+++ b/google-beta/resource_container_cluster_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strconv"
 	"testing"

--- a/google-beta/resource_container_node_pool.go
+++ b/google-beta/resource_container_node_pool.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strings"
 	"time"

--- a/google-beta/resource_container_node_pool_migrate.go
+++ b/google-beta/resource_container_node_pool_migrate.go
@@ -3,7 +3,7 @@ package google
 import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 func resourceContainerNodePoolMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {

--- a/google-beta/resource_container_registry.go
+++ b/google-beta/resource_container_registry.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_data_catalog_entry.go
+++ b/google-beta/resource_data_catalog_entry.go
@@ -17,7 +17,7 @@ package google
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_data_catalog_entry_group.go
+++ b/google-beta/resource_data_catalog_entry_group.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_data_catalog_entry_group_sweeper_test.go
+++ b/google-beta/resource_data_catalog_entry_group_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_data_catalog_entry_sweeper_test.go
+++ b/google-beta/resource_data_catalog_entry_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_data_catalog_policy_tag.go
+++ b/google-beta/resource_data_catalog_policy_tag.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_data_catalog_policy_tag_sweeper_test.go
+++ b/google-beta/resource_data_catalog_policy_tag_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_data_catalog_tag.go
+++ b/google-beta/resource_data_catalog_tag.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_data_catalog_tag_sweeper_test.go
+++ b/google-beta/resource_data_catalog_tag_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_data_catalog_tag_template.go
+++ b/google-beta/resource_data_catalog_tag_template.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_data_catalog_taxonomy.go
+++ b/google-beta/resource_data_catalog_taxonomy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_data_catalog_taxonomy_sweeper_test.go
+++ b/google-beta/resource_data_catalog_taxonomy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_data_fusion_instance.go
+++ b/google-beta/resource_data_fusion_instance.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_data_fusion_instance_sweeper_test.go
+++ b/google-beta/resource_data_fusion_instance_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_data_loss_prevention_deidentify_template.go
+++ b/google-beta/resource_data_loss_prevention_deidentify_template.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_data_loss_prevention_deidentify_template_sweeper_test.go
+++ b/google-beta/resource_data_loss_prevention_deidentify_template_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_data_loss_prevention_inspect_template.go
+++ b/google-beta/resource_data_loss_prevention_inspect_template.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_data_loss_prevention_inspect_template_sweeper_test.go
+++ b/google-beta/resource_data_loss_prevention_inspect_template_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_data_loss_prevention_job_trigger.go
+++ b/google-beta/resource_data_loss_prevention_job_trigger.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_data_loss_prevention_job_trigger_sweeper_test.go
+++ b/google-beta/resource_data_loss_prevention_job_trigger_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_data_loss_prevention_stored_info_type.go
+++ b/google-beta/resource_data_loss_prevention_stored_info_type.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_data_loss_prevention_stored_info_type_sweeper_test.go
+++ b/google-beta/resource_data_loss_prevention_stored_info_type_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_dataflow_flex_template_job.go
+++ b/google-beta/resource_dataflow_flex_template_job.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google-beta/resource_dataflow_job.go
+++ b/google-beta/resource_dataflow_job.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google-beta/resource_dataform_repository.go
+++ b/google-beta/resource_dataform_repository.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_dataform_repository_sweeper_test.go
+++ b/google-beta/resource_dataform_repository_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_dataplex_asset.go
+++ b/google-beta/resource_dataplex_asset.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_dataplex_lake.go
+++ b/google-beta/resource_dataplex_lake.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_dataplex_lake_sweeper_test.go
+++ b/google-beta/resource_dataplex_lake_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	dataplex "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/dataplex/beta"

--- a/google-beta/resource_dataplex_zone.go
+++ b/google-beta/resource_dataplex_zone.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_dataproc_autoscaling_policy.go
+++ b/google-beta/resource_dataproc_autoscaling_policy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_dataproc_autoscaling_policy_sweeper_test.go
+++ b/google-beta/resource_dataproc_autoscaling_policy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_dataproc_cluster.go
+++ b/google-beta/resource_dataproc_cluster.go
@@ -3,7 +3,7 @@ package google
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strconv"
 	"strings"

--- a/google-beta/resource_dataproc_job.go
+++ b/google-beta/resource_dataproc_job.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google-beta/resource_dataproc_job_test.go
+++ b/google-beta/resource_dataproc_job_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 	"time"

--- a/google-beta/resource_dataproc_metastore_federation.go
+++ b/google-beta/resource_dataproc_metastore_federation.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_dataproc_metastore_federation_sweeper_test.go
+++ b/google-beta/resource_dataproc_metastore_federation_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_dataproc_metastore_service.go
+++ b/google-beta/resource_dataproc_metastore_service.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_dataproc_metastore_service_sweeper_test.go
+++ b/google-beta/resource_dataproc_metastore_service_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_dataproc_workflow_template.go
+++ b/google-beta/resource_dataproc_workflow_template.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_dataproc_workflow_template_sweeper_test.go
+++ b/google-beta/resource_dataproc_workflow_template_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	dataproc "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/dataproc/beta"

--- a/google-beta/resource_datastore_index.go
+++ b/google-beta/resource_datastore_index.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_datastream_connection_profile.go
+++ b/google-beta/resource_datastream_connection_profile.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_datastream_connection_profile_sweeper_test.go
+++ b/google-beta/resource_datastream_connection_profile_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_datastream_private_connection.go
+++ b/google-beta/resource_datastream_private_connection.go
@@ -17,7 +17,7 @@ package google
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_datastream_private_connection_sweeper_test.go
+++ b/google-beta/resource_datastream_private_connection_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_datastream_stream.go
+++ b/google-beta/resource_datastream_stream.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_datastream_stream_sweeper_test.go
+++ b/google-beta/resource_datastream_stream_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_deployment_manager_deployment.go
+++ b/google-beta/resource_deployment_manager_deployment.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_deployment_manager_deployment_sweeper_test.go
+++ b/google-beta/resource_deployment_manager_deployment_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_dialogflow_agent.go
+++ b/google-beta/resource_dialogflow_agent.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_dialogflow_cx_agent.go
+++ b/google-beta/resource_dialogflow_cx_agent.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_dialogflow_cx_entity_type.go
+++ b/google-beta/resource_dialogflow_cx_entity_type.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_dialogflow_cx_environment.go
+++ b/google-beta/resource_dialogflow_cx_environment.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_dialogflow_cx_flow.go
+++ b/google-beta/resource_dialogflow_cx_flow.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_dialogflow_cx_intent.go
+++ b/google-beta/resource_dialogflow_cx_intent.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_dialogflow_cx_page.go
+++ b/google-beta/resource_dialogflow_cx_page.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_dialogflow_cx_version.go
+++ b/google-beta/resource_dialogflow_cx_version.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_dialogflow_cx_webhook.go
+++ b/google-beta/resource_dialogflow_cx_webhook.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_dialogflow_entity_type.go
+++ b/google-beta/resource_dialogflow_entity_type.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_dialogflow_fulfillment.go
+++ b/google-beta/resource_dialogflow_fulfillment.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_dialogflow_intent.go
+++ b/google-beta/resource_dialogflow_intent.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_dns_managed_zone.go
+++ b/google-beta/resource_dns_managed_zone.go
@@ -17,7 +17,7 @@ package google
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_dns_policy.go
+++ b/google-beta/resource_dns_policy.go
@@ -17,7 +17,7 @@ package google
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_dns_record_set.go
+++ b/google-beta/resource_dns_record_set.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"strings"
 

--- a/google-beta/resource_dns_response_policy.go
+++ b/google-beta/resource_dns_response_policy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_dns_response_policy_rule.go
+++ b/google-beta/resource_dns_response_policy_rule.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_dns_response_policy_rule_sweeper_test.go
+++ b/google-beta/resource_dns_response_policy_rule_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_document_ai_processor.go
+++ b/google-beta/resource_document_ai_processor.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_document_ai_processor_default_version.go
+++ b/google-beta/resource_document_ai_processor_default_version.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_document_ai_processor_sweeper_test.go
+++ b/google-beta/resource_document_ai_processor_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_endpoints_service.go
+++ b/google-beta/resource_endpoints_service.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strconv"
 	"strings"

--- a/google-beta/resource_endpoints_service_migration.go
+++ b/google-beta/resource_endpoints_service_migration.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 func migrateEndpointsService(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {

--- a/google-beta/resource_essential_contacts_contact.go
+++ b/google-beta/resource_essential_contacts_contact.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_essential_contacts_contact_sweeper_test.go
+++ b/google-beta/resource_essential_contacts_contact_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_eventarc_channel.go
+++ b/google-beta/resource_eventarc_channel.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_eventarc_channel_sweeper_test.go
+++ b/google-beta/resource_eventarc_channel_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	eventarc "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/eventarc/beta"

--- a/google-beta/resource_eventarc_google_channel_config.go
+++ b/google-beta/resource_eventarc_google_channel_config.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_eventarc_trigger.go
+++ b/google-beta/resource_eventarc_trigger.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_eventarc_trigger_sweeper_test.go
+++ b/google-beta/resource_eventarc_trigger_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	eventarc "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/eventarc/beta"

--- a/google-beta/resource_filestore_backup.go
+++ b/google-beta/resource_filestore_backup.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_filestore_backup_sweeper_test.go
+++ b/google-beta/resource_filestore_backup_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_filestore_instance.go
+++ b/google-beta/resource_filestore_instance.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_filestore_instance_sweeper_test.go
+++ b/google-beta/resource_filestore_instance_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_filestore_snapshot.go
+++ b/google-beta/resource_filestore_snapshot.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_filestore_snapshot_sweeper_test.go
+++ b/google-beta/resource_filestore_snapshot_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_firebase_android_app.go
+++ b/google-beta/resource_firebase_android_app.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_firebase_android_app_sweeper_test.go
+++ b/google-beta/resource_firebase_android_app_sweeper_test.go
@@ -8,7 +8,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_firebase_apple_app.go
+++ b/google-beta/resource_firebase_apple_app.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_firebase_apple_app_sweeper_test.go
+++ b/google-beta/resource_firebase_apple_app_sweeper_test.go
@@ -8,7 +8,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_firebase_database_instance.go
+++ b/google-beta/resource_firebase_database_instance.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_firebase_hosting_channel.go
+++ b/google-beta/resource_firebase_hosting_channel.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_firebase_hosting_channel_sweeper_test.go
+++ b/google-beta/resource_firebase_hosting_channel_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_firebase_hosting_site.go
+++ b/google-beta/resource_firebase_hosting_site.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_firebase_hosting_site_sweeper_test.go
+++ b/google-beta/resource_firebase_hosting_site_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_firebase_project.go
+++ b/google-beta/resource_firebase_project.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_firebase_project_location.go
+++ b/google-beta/resource_firebase_project_location.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_firebase_storage_bucket.go
+++ b/google-beta/resource_firebase_storage_bucket.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_firebase_storage_bucket_sweeper_test.go
+++ b/google-beta/resource_firebase_storage_bucket_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_firebase_web_app.go
+++ b/google-beta/resource_firebase_web_app.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_firebase_web_app_sweeper_test.go
+++ b/google-beta/resource_firebase_web_app_sweeper_test.go
@@ -8,7 +8,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_firebaserules_release.go
+++ b/google-beta/resource_firebaserules_release.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_firebaserules_release_sweeper_test.go
+++ b/google-beta/resource_firebaserules_release_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	firebaserules "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/firebaserules/beta"

--- a/google-beta/resource_firebaserules_ruleset.go
+++ b/google-beta/resource_firebaserules_ruleset.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_firebaserules_ruleset_sweeper_test.go
+++ b/google-beta/resource_firebaserules_ruleset_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	firebaserules "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/firebaserules/beta"

--- a/google-beta/resource_firestore_database.go
+++ b/google-beta/resource_firestore_database.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_firestore_document.go
+++ b/google-beta/resource_firestore_document.go
@@ -17,7 +17,7 @@ package google
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"time"

--- a/google-beta/resource_firestore_document_sweeper_test.go
+++ b/google-beta/resource_firestore_document_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_firestore_index.go
+++ b/google-beta/resource_firestore_index.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_folder_access_approval_settings.go
+++ b/google-beta/resource_folder_access_approval_settings.go
@@ -17,7 +17,7 @@ package google
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_game_services_game_server_cluster.go
+++ b/google-beta/resource_game_services_game_server_cluster.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_game_services_game_server_cluster_sweeper_test.go
+++ b/google-beta/resource_game_services_game_server_cluster_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_game_services_game_server_config.go
+++ b/google-beta/resource_game_services_game_server_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_game_services_game_server_config_sweeper_test.go
+++ b/google-beta/resource_game_services_game_server_config_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_game_services_game_server_deployment.go
+++ b/google-beta/resource_game_services_game_server_deployment.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_game_services_game_server_deployment_rollout.go
+++ b/google-beta/resource_game_services_game_server_deployment_rollout.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_game_services_game_server_deployment_rollout_sweeper_test.go
+++ b/google-beta/resource_game_services_game_server_deployment_rollout_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_game_services_game_server_deployment_sweeper_test.go
+++ b/google-beta/resource_game_services_game_server_deployment_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_game_services_realm.go
+++ b/google-beta/resource_game_services_realm.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_game_services_realm_sweeper_test.go
+++ b/google-beta/resource_game_services_realm_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_gke_backup_backup_plan.go
+++ b/google-beta/resource_gke_backup_backup_plan.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_gke_hub_feature.go
+++ b/google-beta/resource_gke_hub_feature.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_gke_hub_feature_membership.go
+++ b/google-beta/resource_gke_hub_feature_membership.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_gke_hub_membership.go
+++ b/google-beta/resource_gke_hub_membership.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_google_project.go
+++ b/google-beta/resource_google_project.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"regexp"
 	"strconv"

--- a/google-beta/resource_google_project_default_service_accounts.go
+++ b/google-beta/resource_google_project_default_service_accounts.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google-beta/resource_google_project_migrate.go
+++ b/google-beta/resource_google_project_migrate.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"google.golang.org/api/cloudresourcemanager/v1"

--- a/google-beta/resource_google_project_service.go
+++ b/google-beta/resource_google_project_service.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google-beta/resource_google_project_test.go
+++ b/google-beta/resource_google_project_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"reflect"
 	"strconv"

--- a/google-beta/resource_google_service_account_key.go
+++ b/google-beta/resource_google_service_account_key.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_google_service_networking_peered_dns_domain.go
+++ b/google-beta/resource_google_service_networking_peered_dns_domain.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 	"time"

--- a/google-beta/resource_healthcare_consent_store.go
+++ b/google-beta/resource_healthcare_consent_store.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_healthcare_consent_store_sweeper_test.go
+++ b/google-beta/resource_healthcare_consent_store_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_healthcare_dataset.go
+++ b/google-beta/resource_healthcare_dataset.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_healthcare_dataset_sweeper_test.go
+++ b/google-beta/resource_healthcare_dataset_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_healthcare_dicom_store.go
+++ b/google-beta/resource_healthcare_dicom_store.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_healthcare_fhir_store.go
+++ b/google-beta/resource_healthcare_fhir_store.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_healthcare_hl7_v2_store.go
+++ b/google-beta/resource_healthcare_hl7_v2_store.go
@@ -17,7 +17,7 @@ package google
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_iam_access_boundary_policy.go
+++ b/google-beta/resource_iam_access_boundary_policy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_iam_access_boundary_policy_sweeper_test.go
+++ b/google-beta/resource_iam_access_boundary_policy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_iam_audit_config.go
+++ b/google-beta/resource_iam_audit_config.go
@@ -3,7 +3,7 @@ package google
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_iam_binding.go
+++ b/google-beta/resource_iam_binding.go
@@ -3,7 +3,7 @@ package google
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/davecgh/go-spew/spew"

--- a/google-beta/resource_iam_deny_policy.go
+++ b/google-beta/resource_iam_deny_policy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_iam_deny_policy_sweeper_test.go
+++ b/google-beta/resource_iam_deny_policy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_iam_member.go
+++ b/google-beta/resource_iam_member.go
@@ -3,7 +3,7 @@ package google
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strings"
 

--- a/google-beta/resource_iam_workforce_pool.go
+++ b/google-beta/resource_iam_workforce_pool.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_iam_workforce_pool_provider.go
+++ b/google-beta/resource_iam_workforce_pool_provider.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_iam_workforce_pool_provider_sweeper_test.go
+++ b/google-beta/resource_iam_workforce_pool_provider_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_iam_workforce_pool_sweeper_test.go
+++ b/google-beta/resource_iam_workforce_pool_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_iam_workload_identity_pool.go
+++ b/google-beta/resource_iam_workload_identity_pool.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_iam_workload_identity_pool_provider.go
+++ b/google-beta/resource_iam_workload_identity_pool_provider.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_iam_workload_identity_pool_provider_sweeper_test.go
+++ b/google-beta/resource_iam_workload_identity_pool_provider_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_iam_workload_identity_pool_sweeper_test.go
+++ b/google-beta/resource_iam_workload_identity_pool_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_iap_brand.go
+++ b/google-beta/resource_iap_brand.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_iap_client.go
+++ b/google-beta/resource_iap_client.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_identity_platform_config.go
+++ b/google-beta/resource_identity_platform_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_identity_platform_default_supported_idp_config.go
+++ b/google-beta/resource_identity_platform_default_supported_idp_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_identity_platform_default_supported_idp_config_sweeper_test.go
+++ b/google-beta/resource_identity_platform_default_supported_idp_config_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_identity_platform_inbound_saml_config.go
+++ b/google-beta/resource_identity_platform_inbound_saml_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_identity_platform_inbound_saml_config_sweeper_test.go
+++ b/google-beta/resource_identity_platform_inbound_saml_config_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_identity_platform_oauth_idp_config.go
+++ b/google-beta/resource_identity_platform_oauth_idp_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_identity_platform_oauth_idp_config_sweeper_test.go
+++ b/google-beta/resource_identity_platform_oauth_idp_config_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_identity_platform_project_default_config.go
+++ b/google-beta/resource_identity_platform_project_default_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_identity_platform_project_default_config_sweeper_test.go
+++ b/google-beta/resource_identity_platform_project_default_config_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_identity_platform_tenant.go
+++ b/google-beta/resource_identity_platform_tenant.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_identity_platform_tenant_default_supported_idp_config.go
+++ b/google-beta/resource_identity_platform_tenant_default_supported_idp_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_identity_platform_tenant_inbound_saml_config.go
+++ b/google-beta/resource_identity_platform_tenant_inbound_saml_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_identity_platform_tenant_inbound_saml_config_sweeper_test.go
+++ b/google-beta/resource_identity_platform_tenant_inbound_saml_config_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_identity_platform_tenant_oauth_idp_config.go
+++ b/google-beta/resource_identity_platform_tenant_oauth_idp_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_identity_platform_tenant_oauth_idp_config_sweeper_test.go
+++ b/google-beta/resource_identity_platform_tenant_oauth_idp_config_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_identity_platform_tenant_sweeper_test.go
+++ b/google-beta/resource_identity_platform_tenant_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_kms_crypto_key.go
+++ b/google-beta/resource_kms_crypto_key.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_kms_crypto_key_version.go
+++ b/google-beta/resource_kms_crypto_key_version.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_kms_key_ring.go
+++ b/google-beta/resource_kms_key_ring.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_kms_key_ring_import_job.go
+++ b/google-beta/resource_kms_key_ring_import_job.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_kms_key_ring_import_job_sweeper_test.go
+++ b/google-beta/resource_kms_key_ring_import_job_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_kms_secret_ciphertext.go
+++ b/google-beta/resource_kms_secret_ciphertext.go
@@ -17,7 +17,7 @@ package google
 import (
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"time"

--- a/google-beta/resource_kms_secret_ciphertext_test.go
+++ b/google-beta/resource_kms_secret_ciphertext_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/google-beta/resource_logging_bucket_config.go
+++ b/google-beta/resource_logging_bucket_config.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strings"
 

--- a/google-beta/resource_logging_log_view.go
+++ b/google-beta/resource_logging_log_view.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_logging_metric.go
+++ b/google-beta/resource_logging_metric.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_logging_metric_sweeper_test.go
+++ b/google-beta/resource_logging_metric_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_memcache_instance.go
+++ b/google-beta/resource_memcache_instance.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_memcache_instance_sweeper_test.go
+++ b/google-beta/resource_memcache_instance_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_ml_engine_model.go
+++ b/google-beta/resource_ml_engine_model.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_ml_engine_model_sweeper_test.go
+++ b/google-beta/resource_ml_engine_model_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_monitoring_alert_policy.go
+++ b/google-beta/resource_monitoring_alert_policy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_monitoring_alert_policy_sweeper_test.go
+++ b/google-beta/resource_monitoring_alert_policy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_monitoring_alert_policy_test.go
+++ b/google-beta/resource_monitoring_alert_policy_test.go
@@ -17,7 +17,7 @@ func TestAccMonitoringAlertPolicy(t *testing.T) {
 		"full":   testAccMonitoringAlertPolicy_full,
 		"update": testAccMonitoringAlertPolicy_update,
 		"mql":    testAccMonitoringAlertPolicy_mql,
-		"log":    testAccMonitoringAlertPolicy_log,
+		log "github.com/sirupsen/logrus":    testAccMonitoringAlertPolicy_log,
 	}
 
 	for name, tc := range testCases {
@@ -303,7 +303,7 @@ resource "google_monitoring_alert_policy" "mql" {
 
 func testAccMonitoringAlertPolicy_logCfg(alertName, conditionName string) string {
 	return fmt.Sprintf(`
-resource "google_monitoring_alert_policy" "log" {
+resource "google_monitoring_alert_policy" log "github.com/sirupsen/logrus" {
   display_name = "%s"
   combiner     = "OR"
   enabled      = true

--- a/google-beta/resource_monitoring_custom_service.go
+++ b/google-beta/resource_monitoring_custom_service.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_monitoring_custom_service_sweeper_test.go
+++ b/google-beta/resource_monitoring_custom_service_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_monitoring_group.go
+++ b/google-beta/resource_monitoring_group.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_monitoring_group_sweeper_test.go
+++ b/google-beta/resource_monitoring_group_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_monitoring_metric_descriptor.go
+++ b/google-beta/resource_monitoring_metric_descriptor.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_monitoring_metric_descriptor_sweeper_test.go
+++ b/google-beta/resource_monitoring_metric_descriptor_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_monitoring_monitored_project.go
+++ b/google-beta/resource_monitoring_monitored_project.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_monitoring_notification_channel.go
+++ b/google-beta/resource_monitoring_notification_channel.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_monitoring_notification_channel_sweeper_test.go
+++ b/google-beta/resource_monitoring_notification_channel_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_monitoring_service.go
+++ b/google-beta/resource_monitoring_service.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_monitoring_service_sweeper_test.go
+++ b/google-beta/resource_monitoring_service_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_monitoring_slo.go
+++ b/google-beta/resource_monitoring_slo.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_monitoring_slo_sweeper_test.go
+++ b/google-beta/resource_monitoring_slo_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_monitoring_uptime_check_config.go
+++ b/google-beta/resource_monitoring_uptime_check_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_monitoring_uptime_check_config_sweeper_test.go
+++ b/google-beta/resource_monitoring_uptime_check_config_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_network_connectivity_hub.go
+++ b/google-beta/resource_network_connectivity_hub.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_network_connectivity_hub_sweeper_test.go
+++ b/google-beta/resource_network_connectivity_hub_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	networkconnectivity "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/networkconnectivity/beta"

--- a/google-beta/resource_network_connectivity_spoke.go
+++ b/google-beta/resource_network_connectivity_spoke.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_network_connectivity_spoke_sweeper_test.go
+++ b/google-beta/resource_network_connectivity_spoke_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	networkconnectivity "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/networkconnectivity/beta"

--- a/google-beta/resource_network_management_connectivity_test_resource.go
+++ b/google-beta/resource_network_management_connectivity_test_resource.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_network_management_connectivity_test_resource_sweeper_test.go
+++ b/google-beta/resource_network_management_connectivity_test_resource_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_network_services_edge_cache_keyset.go
+++ b/google-beta/resource_network_services_edge_cache_keyset.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_network_services_edge_cache_keyset_sweeper_test.go
+++ b/google-beta/resource_network_services_edge_cache_keyset_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_network_services_edge_cache_origin.go
+++ b/google-beta/resource_network_services_edge_cache_origin.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_network_services_edge_cache_origin_sweeper_test.go
+++ b/google-beta/resource_network_services_edge_cache_origin_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_network_services_edge_cache_service.go
+++ b/google-beta/resource_network_services_edge_cache_service.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_network_services_edge_cache_service_sweeper_test.go
+++ b/google-beta/resource_network_services_edge_cache_service_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_notebooks_environment.go
+++ b/google-beta/resource_notebooks_environment.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_notebooks_environment_sweeper_test.go
+++ b/google-beta/resource_notebooks_environment_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_notebooks_instance.go
+++ b/google-beta/resource_notebooks_instance.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_notebooks_instance_sweeper_test.go
+++ b/google-beta/resource_notebooks_instance_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_notebooks_location.go
+++ b/google-beta/resource_notebooks_location.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_notebooks_location_sweeper_test.go
+++ b/google-beta/resource_notebooks_location_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_notebooks_runtime.go
+++ b/google-beta/resource_notebooks_runtime.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_notebooks_runtime_sweeper_test.go
+++ b/google-beta/resource_notebooks_runtime_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_org_policy_custom_constraint.go
+++ b/google-beta/resource_org_policy_custom_constraint.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_org_policy_custom_constraint_sweeper_test.go
+++ b/google-beta/resource_org_policy_custom_constraint_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_org_policy_policy.go
+++ b/google-beta/resource_org_policy_policy.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_organization_access_approval_settings.go
+++ b/google-beta/resource_organization_access_approval_settings.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_os_config_guest_policies.go
+++ b/google-beta/resource_os_config_guest_policies.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_os_config_guest_policies_sweeper_test.go
+++ b/google-beta/resource_os_config_guest_policies_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_os_config_os_policy_assignment.go
+++ b/google-beta/resource_os_config_os_policy_assignment.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google-beta/resource_os_config_os_policy_assignment_sweeper_test.go
+++ b/google-beta/resource_os_config_os_policy_assignment_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	osconfig "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/osconfig/beta"

--- a/google-beta/resource_os_config_patch_deployment.go
+++ b/google-beta/resource_os_config_patch_deployment.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_os_config_patch_deployment_sweeper_test.go
+++ b/google-beta/resource_os_config_patch_deployment_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_os_login_ssh_public_key.go
+++ b/google-beta/resource_os_login_ssh_public_key.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_os_login_ssh_public_key_sweeper_test.go
+++ b/google-beta/resource_os_login_ssh_public_key_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_privateca_ca_pool.go
+++ b/google-beta/resource_privateca_ca_pool.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_privateca_ca_pool_sweeper_test.go
+++ b/google-beta/resource_privateca_ca_pool_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_privateca_certificate.go
+++ b/google-beta/resource_privateca_certificate.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_privateca_certificate_authority.go
+++ b/google-beta/resource_privateca_certificate_authority.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_privateca_certificate_authority_sweeper_test.go
+++ b/google-beta/resource_privateca_certificate_authority_sweeper_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/google-beta/resource_privateca_certificate_template.go
+++ b/google-beta/resource_privateca_certificate_template.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_privateca_certificate_template_sweeper_test.go
+++ b/google-beta/resource_privateca_certificate_template_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	privateca "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/privateca/beta"

--- a/google-beta/resource_project_access_approval_settings.go
+++ b/google-beta/resource_project_access_approval_settings.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_project_service_identity.go
+++ b/google-beta/resource_project_service_identity.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_pubsub_lite_reservation.go
+++ b/google-beta/resource_pubsub_lite_reservation.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_pubsub_lite_reservation_sweeper_test.go
+++ b/google-beta/resource_pubsub_lite_reservation_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_pubsub_lite_subscription.go
+++ b/google-beta/resource_pubsub_lite_subscription.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_pubsub_lite_subscription_sweeper_test.go
+++ b/google-beta/resource_pubsub_lite_subscription_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_pubsub_lite_topic.go
+++ b/google-beta/resource_pubsub_lite_topic.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_pubsub_lite_topic_sweeper_test.go
+++ b/google-beta/resource_pubsub_lite_topic_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_pubsub_schema.go
+++ b/google-beta/resource_pubsub_schema.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_pubsub_schema_sweeper_test.go
+++ b/google-beta/resource_pubsub_schema_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_pubsub_subscription.go
+++ b/google-beta/resource_pubsub_subscription.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_pubsub_subscription_sweeper_test.go
+++ b/google-beta/resource_pubsub_subscription_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_pubsub_topic.go
+++ b/google-beta/resource_pubsub_topic.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_pubsub_topic_sweeper_test.go
+++ b/google-beta/resource_pubsub_topic_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_recaptcha_enterprise_key.go
+++ b/google-beta/resource_recaptcha_enterprise_key.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_recaptcha_enterprise_key_sweeper_test.go
+++ b/google-beta/resource_recaptcha_enterprise_key_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	recaptchaenterprise "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/recaptchaenterprise/beta"

--- a/google-beta/resource_redis_instance.go
+++ b/google-beta/resource_redis_instance.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strconv"

--- a/google-beta/resource_redis_instance_sweeper_test.go
+++ b/google-beta/resource_redis_instance_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_resource_manager_lien.go
+++ b/google-beta/resource_resource_manager_lien.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_scc_notification_config.go
+++ b/google-beta/resource_scc_notification_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_scc_notification_config_sweeper_test.go
+++ b/google-beta/resource_scc_notification_config_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_scc_source.go
+++ b/google-beta/resource_scc_source.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_secret_manager_secret.go
+++ b/google-beta/resource_secret_manager_secret.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_secret_manager_secret_sweeper_test.go
+++ b/google-beta/resource_secret_manager_secret_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_secret_manager_secret_version.go
+++ b/google-beta/resource_secret_manager_secret_version.go
@@ -17,7 +17,7 @@ package google
 import (
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_security_scanner_scan_config.go
+++ b/google-beta/resource_security_scanner_scan_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_security_scanner_scan_config_sweeper_test.go
+++ b/google-beta/resource_security_scanner_scan_config_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_service_directory_endpoint.go
+++ b/google-beta/resource_service_directory_endpoint.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_service_directory_namespace.go
+++ b/google-beta/resource_service_directory_namespace.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_service_directory_service.go
+++ b/google-beta/resource_service_directory_service.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_service_networking_connection.go
+++ b/google-beta/resource_service_networking_connection.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/url"
 	"regexp"
 	"strings"

--- a/google-beta/resource_service_usage_consumer_quota_override.go
+++ b/google-beta/resource_service_usage_consumer_quota_override.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_sourcerepo_repository.go
+++ b/google-beta/resource_sourcerepo_repository.go
@@ -17,7 +17,7 @@ package google
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_sourcerepo_repository_sweeper_test.go
+++ b/google-beta/resource_sourcerepo_repository_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_spanner_database.go
+++ b/google-beta/resource_spanner_database.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strconv"

--- a/google-beta/resource_spanner_instance.go
+++ b/google-beta/resource_spanner_instance.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_spanner_instance_sweeper_test.go
+++ b/google-beta/resource_spanner_instance_sweeper_test.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/google-beta/resource_sql_database.go
+++ b/google-beta/resource_sql_database.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_sql_database_instance.go
+++ b/google-beta/resource_sql_database_instance.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google-beta/resource_sql_database_instance_sweeper_test.go
+++ b/google-beta/resource_sql_database_instance_sweeper_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google-beta/resource_sql_source_representation_instance.go
+++ b/google-beta/resource_sql_source_representation_instance.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strconv"
 	"strings"

--- a/google-beta/resource_sql_source_representation_instance_sweeper_test.go
+++ b/google-beta/resource_sql_source_representation_instance_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_sql_ssl_cert.go
+++ b/google-beta/resource_sql_ssl_cert.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_sql_user.go
+++ b/google-beta/resource_sql_user.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google-beta/resource_sql_user_migrate.go
+++ b/google-beta/resource_sql_user_migrate.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )

--- a/google-beta/resource_storage_bucket.go
+++ b/google-beta/resource_storage_bucket.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"math"
 	"runtime"
 	"strconv"

--- a/google-beta/resource_storage_bucket_access_control.go
+++ b/google-beta/resource_storage_bucket_access_control.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_storage_bucket_acl.go
+++ b/google-beta/resource_storage_bucket_acl.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 

--- a/google-beta/resource_storage_bucket_object.go
+++ b/google-beta/resource_storage_bucket_object.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
 	"time"

--- a/google-beta/resource_storage_bucket_sweeper_test.go
+++ b/google-beta/resource_storage_bucket_sweeper_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/google-beta/resource_storage_bucket_test.go
+++ b/google-beta/resource_storage_bucket_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"testing"
 	"time"

--- a/google-beta/resource_storage_default_object_access_control.go
+++ b/google-beta/resource_storage_default_object_access_control.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_storage_hmac_key.go
+++ b/google-beta/resource_storage_hmac_key.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_storage_object_access_control.go
+++ b/google-beta/resource_storage_object_access_control.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_storage_transfer_agent_pool.go
+++ b/google-beta/resource_storage_transfer_agent_pool.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_storage_transfer_agent_pool_sweeper_test.go
+++ b/google-beta/resource_storage_transfer_agent_pool_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_storage_transfer_job.go
+++ b/google-beta/resource_storage_transfer_job.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_tags_location_tag_bindings.go
+++ b/google-beta/resource_tags_location_tag_bindings.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_tags_tag_binding.go
+++ b/google-beta/resource_tags_tag_binding.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_tags_tag_binding_sweeper_test.go
+++ b/google-beta/resource_tags_tag_binding_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_tags_tag_key.go
+++ b/google-beta/resource_tags_tag_key.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_tags_tag_key_sweeper_test.go
+++ b/google-beta/resource_tags_tag_key_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_tags_tag_value.go
+++ b/google-beta/resource_tags_tag_value.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_tags_tag_value_sweeper_test.go
+++ b/google-beta/resource_tags_tag_value_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_tpu_node.go
+++ b/google-beta/resource_tpu_node.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"time"

--- a/google-beta/resource_tpu_node_sweeper_test.go
+++ b/google-beta/resource_tpu_node_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_usage_export_bucket.go
+++ b/google-beta/resource_usage_export_bucket.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/resource_vertex_ai_dataset.go
+++ b/google-beta/resource_vertex_ai_dataset.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_vertex_ai_endpoint.go
+++ b/google-beta/resource_vertex_ai_endpoint.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_vertex_ai_endpoint_sweeper_test.go
+++ b/google-beta/resource_vertex_ai_endpoint_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_vertex_ai_featurestore.go
+++ b/google-beta/resource_vertex_ai_featurestore.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_vertex_ai_featurestore_entitytype.go
+++ b/google-beta/resource_vertex_ai_featurestore_entitytype.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_vertex_ai_featurestore_entitytype_feature.go
+++ b/google-beta/resource_vertex_ai_featurestore_entitytype_feature.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google-beta/resource_vertex_ai_index.go
+++ b/google-beta/resource_vertex_ai_index.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_vertex_ai_index_sweeper_test.go
+++ b/google-beta/resource_vertex_ai_index_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_vertex_ai_metadata_store.go
+++ b/google-beta/resource_vertex_ai_metadata_store.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_vertex_ai_tensorboard.go
+++ b/google-beta/resource_vertex_ai_tensorboard.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_vpc_access_connector.go
+++ b/google-beta/resource_vpc_access_connector.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google-beta/resource_vpc_access_connector_sweeper_test.go
+++ b/google-beta/resource_vpc_access_connector_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_workflows_workflow.go
+++ b/google-beta/resource_workflows_workflow.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_workflows_workflow_sweeper_test.go
+++ b/google-beta/resource_workflows_workflow_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/resource_workstations_workstation_cluster.go
+++ b/google-beta/resource_workstations_workstation_cluster.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google-beta/resource_workstations_workstation_cluster_sweeper_test.go
+++ b/google-beta/resource_workstations_workstation_cluster_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google-beta/retry_transport.go
+++ b/google-beta/retry_transport.go
@@ -35,7 +35,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"net/http/httputil"
 	"time"

--- a/google-beta/retry_utils.go
+++ b/google-beta/retry_utils.go
@@ -1,7 +1,7 @@
 package google
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/errwrap"

--- a/google-beta/security_policy_association_utils.go
+++ b/google-beta/security_policy_association_utils.go
@@ -1,7 +1,7 @@
 package google
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/errwrap"

--- a/google-beta/service_usage_operation.go
+++ b/google-beta/service_usage_operation.go
@@ -17,7 +17,7 @@ package google
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google-beta/serviceusage_batching.go
+++ b/google-beta/serviceusage_batching.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google-beta/sql_utils.go
+++ b/google-beta/sql_utils.go
@@ -1,7 +1,7 @@
 package google
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/errwrap"

--- a/google-beta/sqladmin_operation.go
+++ b/google-beta/sqladmin_operation.go
@@ -3,7 +3,7 @@ package google
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"

--- a/google-beta/tpgtools_utils.go
+++ b/google-beta/tpgtools_utils.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	dcl "github.com/GoogleCloudPlatform/declarative-resource-client-library/dcl"
 	"github.com/hashicorp/errwrap"

--- a/google-beta/utils.go
+++ b/google-beta/utils.go
@@ -4,7 +4,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"regexp"
 	"sort"

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"flag"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"

--- a/scripts/affectedtests/affectedtests.go
+++ b/scripts/affectedtests/affectedtests.go
@@ -19,7 +19,7 @@ import (
 	"go/parser"
 	"go/token"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"os"
 	"path/filepath"


### PR DESCRIPTION
Use logrus for logging instead of standard log library

[_Created by Sourcegraph batch change `admin/use-logrus-in-terraform-providers`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/use-logrus-in-terraform-providers)